### PR TITLE
Rename total_points column to total_pts in season scoring leaders

### DIFF
--- a/nba/models/marts/mart_season_scoring_leaders.sql
+++ b/nba/models/marts/mart_season_scoring_leaders.sql
@@ -3,7 +3,7 @@ WITH player_season_stats AS (
         player_id,
         player_name,
         season,
-        SUM(points) as total_points,
+        SUM(points) as total_pts,
         COUNT(DISTINCT game_id) as games_played,
         ROUND(SUM(points)::FLOAT / COUNT(DISTINCT game_id), 2) as points_per_game
     FROM 


### PR DESCRIPTION
Fixes issue with column naming in mart_season_scoring_leaders